### PR TITLE
SPIFFS is currently deprecated. It is recommended to use LittleFS instead.

### DIFF
--- a/JeeUI2.h
+++ b/JeeUI2.h
@@ -9,7 +9,7 @@
 #include <FS.h>
 #else
 #include <AsyncTCP.h>
-#include "SPIFFS.h"
+#include "LittleFS.h"
 #endif
 
 #include <ESPAsyncWebServer.h>

--- a/config.cpp
+++ b/config.cpp
@@ -2,9 +2,9 @@
 
 void jeeui2::save()
 {
-    if(SPIFFS.begin()){
+    if(LittleFS.begin()){
     }
-    File configFile = SPIFFS.open(F("/config.json"), "w");
+    File configFile = LittleFS.open(F("/config.json"), "w");
     
     String cfg_str;
     serializeJson(cfg, cfg_str);
@@ -39,9 +39,9 @@ void jeeui2::as(){
 
 void jeeui2::load()
 {
-    if(SPIFFS.begin()){
+    if(LittleFS.begin()){
     }
-    File pre_configFile = SPIFFS.open(F("/config.json"), "r");
+    File pre_configFile = LittleFS.open(F("/config.json"), "r");
     if (pre_configFile.readString() == "")
     {
         if(dbg)Serial.println(F("Failed to open config file"));

--- a/config.h
+++ b/config.h
@@ -4,7 +4,7 @@
 #ifdef ESP8266
 #include <FS.h>
 #else
-#include "SPIFFS.h"
+#include "LittleFS.h"
 #endif
 
 #endif

--- a/gpio.cpp
+++ b/gpio.cpp
@@ -53,7 +53,7 @@ void jeeui2::btn()
         if (t + 15000 < millis()) // Нажатие 10 секунд
         {
             led_inv();
-            SPIFFS.remove("/config.json");
+            LittleFS.remove("/config.json");
             ESP.restart();
         }
     }


### PR DESCRIPTION
SPIFFS is currently deprecated and may be removed in future releases of the ESP8266
core. It is recommended to use LittleFS instead.